### PR TITLE
check that error is an object explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ var options = {
 1. You will still see the normal console.log, console.warn, and console.error behavior, in addition to the slack messages.
 
 ## Changelog
+- **0.1.2**:
+	- FIXED: Explicit check for the error being an object before referencing its properties.
 - **0.1.1**:
 	- ADDED: Support for finding strack trace in errors recursively.
 - **0.1.0**:

--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ var slackWebhooks = function() {
 			// Have support for errors that are both strings and objects
 			if (typeof err === 'string') {
 				attachment.pretext += `*CustomError*: ${err}\n`;
-			} else {
+			} else if (typeof err === 'object') {
 				attachment.pretext += `*${err.name}*: ${err.message}\n`;
 
 				const stackTrace = _findStackTrace(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "console-to-slack",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Module for integrating console usage with Slack webhooks.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
this adds a safety check to ensure that the error object is in fact an object before calling its properties.